### PR TITLE
fix: Resolve Worker SecurityError on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
         {name: i18n.t("playerName"), type: LocalPlayer},
         {
             name: "Stockfish", type: StockfishPlayer, props: {
-                worker: "https://cdn.jsdelivr.net/npm/cm-engine-runner@1.2.4/engines/stockfish-v10-niklasf.js",
+                worker: "./src/stockfish-worker-proxy.js",
                 book: "./assets/books/openings.bin",
                 level: 1,
                 debug: true

--- a/src/stockfish-worker-proxy.js
+++ b/src/stockfish-worker-proxy.js
@@ -1,0 +1,5 @@
+/**
+ * Proxy for the Stockfish web worker to circumvent same-origin policy.
+ * Loads the actual engine from CDN using importScripts.
+ */
+importScripts("https://cdn.jsdelivr.net/npm/cm-engine-runner@1.2.4/engines/stockfish-v10-niklasf.js");


### PR DESCRIPTION
The Stockfish web worker failed to load on GitHub Pages because of same-origin policy restrictions when using a CDN URL directly in `new Worker()`.

- Created `src/stockfish-worker-proxy.js` which uses `importScripts()` to load the engine from the CDN.
- Updated `index.html` to point to this local proxy script.
- Verified that the engine initializes and responds to UCI commands in the console.