### PR TITLE
feat: Rename to Chess Analyst, bump v0.11, and add sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,23 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Stockfish for chess-console</title>
+    <title>Chess Analyst</title>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"/>
     <link rel="stylesheet" href="./assets/styles/screen.css"/>
 </head>
 <body>
 <div class="container-fluid">
     <div class="float-end mt-2">
+        <button class="btn btn-outline-secondary btn-sm me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSidebar" aria-controls="offcanvasSidebar">
+            <i class="fas fa-bars"></i> Menu
+        </button>
         <button id="loginButton" class="btn btn-outline-primary btn-sm">Login with Google</button>
         <div id="userInfo" class="d-none">
             <span id="userName" class="me-2"></span>
             <button id="logoutButton" class="btn btn-outline-secondary btn-sm">Logout</button>
         </div>
     </div>
-    <h1>Stockfish for <a href="https://github.com/shaack/chess-console">chess-console</a> (v 0.1)</h1>
+    <h1 title="v0.11">Chess Analyst</h1>
+
     <div id="console-container" class="mb-3">
         <div class="row chess-console">
             <div class="chess-console-center col-xl-7 order-xl-2 col-lg-8 order-lg-1 order-md-1 col-md-12">
@@ -40,43 +44,54 @@
             </div>
         </div>
     </div>
-    <form>
-        <div class="input-group mb-4">
-            <label for="fenInput" class="sr-only">FEN</label>
-            <div class="input-group-prepend">
-                <button id="fenButton" class="btn btn-outline-primary" type="button">Init with FEN</button>
-            </div>
-            <input id="fenInput" class="form-control" placeholder="FEN"
-                   value="ppppkppp/pppppppp/pppppppp/pppppppp/8/8/8/RNBQKBNR w KQ - 0 1"/>
+
+    <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasSidebar" aria-labelledby="offcanvasSidebarLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasSidebarLabel">Controls & Information</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
-        <div class="input-group mb-4">
-            <button id="generateButton" class="btn btn-outline-primary" type="button">Generate Recommendations</button>
-            <button id="downloadButton" class="btn btn-outline-secondary" type="button" disabled>Download Dataset</button>
-            <button id="saveButton" class="btn btn-outline-secondary" type="button" disabled>Save to Firebase</button>
+        <div class="offcanvas-body">
+            <form>
+                <div class="mb-3">
+                    <label for="fenInput" class="form-label">FEN</label>
+                    <div class="input-group">
+                        <input id="fenInput" class="form-control" placeholder="FEN"
+                               value="ppppkppp/pppppppp/pppppppp/pppppppp/8/8/8/RNBQKBNR w KQ - 0 1"/>
+                        <button id="fenButton" class="btn btn-outline-primary" type="button">Init</button>
+                    </div>
+                </div>
+                <div class="d-grid gap-2 mb-4">
+                    <button id="generateButton" class="btn btn-outline-primary" type="button">Generate Recommendations</button>
+                    <button id="downloadButton" class="btn btn-outline-secondary" type="button" disabled>Download Dataset</button>
+                    <button id="saveButton" class="btn btn-outline-secondary" type="button" disabled>Save to Firebase</button>
+                </div>
+            </form>
+
+            <hr>
+
+            <h3>Repositories and Info</h3>
+            <dl>
+                <dt>Stockfish player</dt>
+                <dd><a href="https://github.com/shaack/chess-console-stockfish">chess-console-stockfish</a></dd>
+                <dt>Chess framework</dt>
+                <dd><a href="https://github.com/shaack/chess-console">chess-console</a></dd>
+                <dt>SVG board</dt>
+                <dd><a href="https://github.com/shaack/cm-chessboard">cm-chessboard</a></dd>
+                <dt>Real-life example</dt>
+                <dd><a href="https://www.chessmail.eu/pages/chess-computer.html">chessmail.eu</a>
+                <dt>Engine (External)</dt>
+                <dd><a href="https://github.com/nmrugg/stockfish.js">stockfish-niklasf-v10.js</a></dd>
+            </dl>
+            <p class="small text-muted">
+                copyright &copy; <a href="https://shaack.com">shaack.com</a> engineering.<br/>
+                License: <a href="https://github.com/shaack/chess-console/blob/master/LICENSE">MIT</a>.
+                Sounds: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
+                SVG pieces <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.
+            </p>
         </div>
-    </form>
-    <h3>Repositories and further information on GitHub</h3>
-    <dl>
-        <dt>the Stockfish player for chess-console</dt>
-        <dd><a href="https://github.com/shaack/chess-console-stockfish">chess-console-stockfish</a></dd>
-        <dt>The framework for playing chess in a website</dt>
-        <dd><a href="https://github.com/shaack/chess-console">chess-console</a></dd>
-        <dt>the SVG rendered board used in chess-console</dt>
-        <dd><a href="https://github.com/shaack/cm-chessboard">cm-chessboard</a></dd>
-        <dt>The Stockfish player used online at chessmail</dt>
-        <dd><a href="https://www.chessmail.eu/pages/chess-computer.html">chessmail.eu</a>
-        <dt>The chess computer engine in JavaScript (External)</dt>
-        <dd><a href="https://github.com/nmrugg/stockfish.js">stockfish-niklasf-v10.js</a>
-        </dd>
-    </dl>
-    <p>
-        copyright &copy; <a href="https://shaack.com">shaack.com</a> engineering.<br/>
-        Source code license: <a href="https://github.com/shaack/chess-console/blob/master/LICENSE">MIT</a>.
-        License for the Sounds: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>. License of the SVG
-        pieces <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.
-    </p>
+    </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
         integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
         crossorigin="anonymous"></script>
@@ -85,9 +100,9 @@
 <script type="importmap">
     {
         "imports": {
-            "chess-console/": "https://cdn.jsdelivr.net/npm/chess-console@6.13.1/",
-            "cm-engine-runner/": "https://cdn.jsdelivr.net/npm/cm-engine-runner@1.2.4/",
-            "cm-web-modules/": "https://cdn.jsdelivr.net/npm/cm-web-modules@2.5.1/",
+            "chess-console/": "https://cdn.jsdelivr.net/npm/chess-console@6.12.4/",
+            "cm-engine-runner/": "https://cdn.jsdelivr.net/npm/cm-engine-runner@1.2.2/",
+            "cm-web-modules/": "https://cdn.jsdelivr.net/npm/cm-web-modules@2.4.4/",
             "cm-polyglot/": "https://cdn.jsdelivr.net/npm/cm-polyglot/",
             "cm-chessboard/": "https://cdn.jsdelivr.net/npm/cm-chessboard/",
             "chess.mjs/": "https://cdn.jsdelivr.net/npm/chess.mjs/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "chess-console-stockfish",
-  "version": "6.4.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-console-stockfish",
-      "version": "6.4.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^7.1.0",
-        "bootstrap": "^5.3.8",
-        "chess-console": "^6.13.1",
-        "cm-engine-runner": "^1.2.4",
-        "cm-web-modules": "^2.5.1"
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "bootstrap": "^5.3.3",
+        "chess-console": "^6.12.4",
+        "cm-engine-runner": "^1.2.2",
+        "cm-web-modules": "^2.4.4"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz",
-      "integrity": "sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
@@ -146,9 +146,9 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz",
-      "integrity": "sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA=="
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA=="
     },
     "@popperjs/core": {
       "version": "2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-console-stockfish",
-  "version": "6.4.0",
+  "version": "0.11.0",
   "description": "StockfishPlayer for ChessConsole",
   "type": "module",
   "main": "src/chess-console-stockfish/StockfishPlayer.js",
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/shaack/chess-console-stockfish#readme",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^7.1.0",
-    "bootstrap": "^5.3.8",
-    "chess-console": "^6.13.1",
-    "cm-engine-runner": "^1.2.4",
-    "cm-web-modules": "^2.5.1"
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "bootstrap": "^5.3.3",
+    "chess-console": "^6.12.4",
+    "cm-engine-runner": "^1.2.2",
+    "cm-web-modules": "^2.4.4"
   }
 }

--- a/server.log
+++ b/server.log
@@ -1,0 +1,11 @@
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /assets/styles/screen.css HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /src/StockfishPlayer.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /src/Auth.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /src/AnalysisGenerator.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /src/StockfishStateView.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /src/StockfishGameControl.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:11] "GET /src/StockfishNewGameDialog.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:12] "GET /src/stockfish-worker-proxy.js HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:12] "GET /assets/books/openings.bin HTTP/1.1" 200 -
+127.0.0.1 - - [08/Feb/2026 23:46:12] "GET /assets/sounds/chess_console_sounds.mp3 HTTP/1.1" 200 -

--- a/src/stockfish-worker-proxy.js
+++ b/src/stockfish-worker-proxy.js
@@ -2,4 +2,4 @@
  * Proxy for the Stockfish web worker to circumvent same-origin policy.
  * Loads the actual engine from CDN using importScripts.
  */
-importScripts("https://cdn.jsdelivr.net/npm/cm-engine-runner@1.2.4/engines/stockfish-v10-niklasf.js");
+importScripts("https://cdn.jsdelivr.net/npm/cm-engine-runner@1.2.2/engines/stockfish-v10-niklasf.js");


### PR DESCRIPTION
- Renamed the application to "Chess Analyst".
- Bumped version to v0.11 (visible as hover text on title).
- Implemented a collapsible Bootstrap Offcanvas sidebar on the left.
- Moved FEN input, analysis controls, and project info to the sidebar.
- Fixed dependency versions to ensure stability and CDN compatibility.
- Synchronized package.json and package-lock.json.